### PR TITLE
Add 'Transforma tu trabajo con Notion' event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
+*.log
 
 # env files (can opt-in for committing if needed)
 .env*

--- a/app/data/events.ts
+++ b/app/data/events.ts
@@ -259,5 +259,18 @@ export const EVENTS: IEvent[] = [
         registration_url: "https://luma.com/ziz7wesi",
         tags: ["Tech"],
         organizer: "Soleil Kamitto Nuñez Pumacallahui & 6 others"
+    },
+    {
+        title: "Transforma tu trabajo con Notion",
+        description: "¿Sientes que el potencial de tu equipo o de tu proyecto se pierde entre archivos dispersos y procesos lentos? Es hora de centralizar. 🧠✨\nEn Transforma tu trabajo con Notion, vamos a ir más allá de las notas simples. Exploraremos cómo esta herramienta está revolucionando desde la creación de negocios digitales hasta la gestión en el sector público y las aulas. Ven a descubrir cómo convertir a Notion en el motor de tu productividad.",
+        date: "2026-03-14",
+        time: "18:00",
+        location: "San Isidro",
+        city: "Lima",
+        type: "Presencial",
+        image_url: "https://images.lumacdn.com/cdn-cgi/image/format=auto,fit=cover,dpr=2,background=white,quality=75,width=400,height=400/event-covers/j7/db3092ab-b3ca-4043-86a1-fc0838d9db43.jpg",
+        registration_url: "https://luma.com/67pvhxje",
+        tags: ["Notion"],
+        organizer: "Notion Perú"
     }
 ];


### PR DESCRIPTION
I have added the new event 'Transforma tu trabajo con Notion' to the `app/data/events.ts` file with all the details provided. The event is scheduled for March 14, 2026, in San Isidro, Lima. I also performed frontend verification using Playwright and ensured that the codebase remains clean by updating `.gitignore` to exclude log files and restoring the `package-lock.json` to its original state.

Fixes #30

---
*PR created automatically by Jules for task [7289433251246340632](https://jules.google.com/task/7289433251246340632) started by @lperezp*