### PR TITLE
Add LEAD TALENT SHOWCASE event

### DIFF
--- a/app/data/events.ts
+++ b/app/data/events.ts
@@ -424,5 +424,18 @@ export const EVENTS: IEvent[] = [
         registration_url: "https://luma.com/ze8sf4kq?tk=8Sr06Q",
         tags: ["AI", "GitHub Copilot"],
         organizer: "Cloud Experts Community"
+    },
+    {
+        title: "LEAD TALENT SHOWCASE",
+        description: "¿Listo para el siguiente nivel de tu carrera? LEAD Talent Showcase es el punto de encuentro definitivo para el talento joven más prometedor. Conecta con los miembros más destacados de diversos chapters de LEAD Peru y descubre, a través de sus historias de éxito, la hoja de ruta real para tu futuro profesional.",
+        date: "2026-03-07",
+        time: "15:00",
+        location: "UTP - Torre Arequipa",
+        city: "Lima",
+        type: "Presencial",
+        image_url: "https://images.lumacdn.com/cdn-cgi/image/format=auto,fit=cover,dpr=2,anim=false,background=white,quality=75,width=500,height=500/event-covers/4f/e382ae24-9583-4590-ba1c-08a68fa09ba5.png",
+        registration_url: "https://luma.com/d9vlwfq5",
+        tags: ["Tech"],
+        organizer: "LEAD UTP"
     }
 ];


### PR DESCRIPTION
I have added the "LEAD TALENT SHOWCASE" event to the `app/data/events.ts` file. 

Key actions taken:
- Extracted event metadata (title, description, date, time, location, image) from the Luma URL `https://luma.com/d9vlwfq5`.
- Appended the new event to the `EVENTS` array in `app/data/events.ts`.
- Verified the frontend rendering by running a development server and capturing a screenshot with Playwright.
- Ensured code quality by running `npm run lint`.
- Cleaned up all temporary verification files and reverted unrelated environment changes in `package-lock.json`.

Fixes #50

---
*PR created automatically by Jules for task [11239473042256453998](https://jules.google.com/task/11239473042256453998) started by @lperezp*