### PR TITLE
Update GDG Callao logo

### DIFF
--- a/app/data/communities.ts
+++ b/app/data/communities.ts
@@ -27,7 +27,7 @@ export const COMMUNITIES: ICommunity[] = [
     {
         "name": "Google Developers Group Callao",
         "description": "Google Developers Groups Callao es una iniciativa para concentrar los esfuerzos de muchos desarrolladores en el Callao y sus alrededores para aprender, compartir y ser productivos utilizando los diversos productos de Google.",
-        "logo_url": "https://gdgcallao.dev/assets/icons/ic_gdgcallao_black.svg",
+        "logo_url": "https://avatars.githubusercontent.com/u/137642496?v=4",
         "city": "Callao",
         "topics": [
             "Angular",

--- a/app/data/communities.ts
+++ b/app/data/communities.ts
@@ -27,7 +27,7 @@ export const COMMUNITIES: ICommunity[] = [
     {
         "name": "Google Developers Group Callao",
         "description": "Google Developers Groups Callao es una iniciativa para concentrar los esfuerzos de muchos desarrolladores en el Callao y sus alrededores para aprender, compartir y ser productivos utilizando los diversos productos de Google.",
-        "logo_url": "https://avatars.githubusercontent.com/u/137642496?v=4",
+        "logo_url": "https://gdgcallao.vercel.app/assets/icons/ic_gdgcallao_black.svg",
         "city": "Callao",
         "topics": [
             "Angular",


### PR DESCRIPTION
Updated the `logo_url` for GDG Callao in `app/data/communities.ts`. Verified the change visually by running the development server and capturing a screenshot of the communities page. Ran `npm run lint` to ensure code quality.

Fixes #59

---
*PR created automatically by Jules for task [1470737389594491341](https://jules.google.com/task/1470737389594491341) started by @lperezp*