### PR TITLE
Add Open Claw Workshop Event

### DIFF
--- a/app/data/events.ts
+++ b/app/data/events.ts
@@ -541,5 +541,18 @@ export const EVENTS: IEvent[] = [
         registration_url: "https://gdg.community.dev/events/details/google-gdg-open-presents-build-with-ai-2026-gdg-open/",
         tags: ["AI", "GDG", "Google"],
         organizer: "GDG Open"
+    },
+    {
+        title: "Taller Gratuito Aprende a Instalar Open Claw en 90 minutos",
+        description: "¿Quieres usar Open Claw pero no sabes por dónde empezar? En este taller en vivo vamos a instalarlo juntos, paso a paso. Al final de los 90 minutos tendrás Open Claw corriendo en un entorno seguro. 🎯 ¿Qué vas a aprender? Qué es Open Claw y para qué sirve. Cómo descargarlo e instalarlo correctamente en un servidor seguro. Configuración inicial desde cero. Cómo solucionar los errores más comunes.",
+        date: "2026-03-14",
+        time: "10:00",
+        location: "Google Meet",
+        city: "Lima",
+        type: "Virtual",
+        image_url: "https://images.lumacdn.com/cdn-cgi/image/format=auto,fit=cover,dpr=2,background=white,quality=75,width=400,height=400/event-covers/f5/d216810a-f347-4920-8c00-02e0896f25dd.png",
+        registration_url: "https://luma.com/9906kkux",
+        tags: ["AI", "Open Claw", "IA"],
+        organizer: "Ande Studio"
     }
 ];


### PR DESCRIPTION
Added the "Taller Gratuito Aprende a Instalar Open Claw en 90 minutos" event to `app/data/events.ts`. The event is scheduled for March 14, 2026, and is organized by Ande Studio.

Verified the change by:
1. Running `npm run lint` to ensure code quality.
2. Starting the development server and using a Playwright script to confirm the event appears on the `/events` page.
3. Capturing a screenshot for visual verification.
4. Reverting unrelated changes to `package-lock.json` caused by the local environment.

Fixes #62

---
*PR created automatically by Jules for task [5349917579604593225](https://jules.google.com/task/5349917579604593225) started by @lperezp*