### PR TITLE
feat: add structured data to home, events, and projects

### DIFF
--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -2,6 +2,8 @@ import Link from 'next/link';
 import type { Metadata } from 'next';
 import EventsClient from '../components/events/EventsClient';
 import { addUTMParams } from '../lib/utm';
+import { EVENTS } from '../data/events';
+import { eventSchema, itemListSchema } from '../lib/structured-data';
 
 export const metadata: Metadata = {
     title: 'Eventos tecnológicos en Perú | Peruanos.dev',
@@ -23,8 +25,21 @@ export const metadata: Metadata = {
 };
 
 export default function Events() {
+    const jsonLdEvents = itemListSchema(EVENTS.map(event => eventSchema({
+        name: event.title,
+        description: event.description,
+        startDate: event.date,
+        location: event.location,
+        organizer: event.organizer || '',
+        url: event.registration_url,
+    })));
+
     return (
         <main className="flex w-full max-w-7xl flex-col items-center bg-background mx-auto">
+            <script
+                type="application/ld+json"
+                dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLdEvents) }}
+            />
             <section className="py-20 flex flex-col items-start w-full px-8 sm:px-10">
                 <h1 className="text-4xl sm:text-6xl text-left font-bold mb-4 leading-[1.4] w-full">
                     Próximos <span className="text-primary-text">eventos</span>

--- a/app/lib/structured-data.ts
+++ b/app/lib/structured-data.ts
@@ -74,3 +74,33 @@ export const eventSchema = (event: {
     eventStatus: 'https://schema.org/EventScheduled',
     ...(event.url && { url: event.url }),
 });
+
+export const softwareSourceCodeSchema = (project: {
+    name: string;
+    description: string;
+    codeRepository: string;
+    author: string;
+}) => ({
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareSourceCode',
+    name: project.name,
+    description: project.description,
+    codeRepository: project.codeRepository,
+    author: {
+        '@type': 'Person',
+        name: project.author,
+    },
+});
+
+export const itemListSchema = (items: Record<string, unknown>[]) => ({
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    itemListElement: items.map((item, index) => ({
+        '@type': 'ListItem',
+        position: index + 1,
+        item: {
+            '@context': undefined,
+            ...item
+        },
+    })),
+});

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,6 +12,7 @@ import { PROJECTS } from './data/projects';
 import { IGitHubRepo } from './models/project.model';
 import { CircleCheck, Edit, GitFork, Github } from 'lucide-react';
 import { addUTMParams } from './lib/utm';
+import { eventSchema, itemListSchema, softwareSourceCodeSchema } from './lib/structured-data';
 
 export const metadata: Metadata = {
   title: 'Inicio | Peruanos.dev',
@@ -58,8 +59,32 @@ export default async function Home() {
     })
   ).then(results => results.filter(Boolean));
 
+  const jsonLdEvents = itemListSchema(upcomingEvents.map(event => eventSchema({
+    name: event.title,
+    description: event.description,
+    startDate: event.date,
+    location: event.location,
+    organizer: event.organizer || '',
+    url: event.registration_url,
+  })));
+
+  const jsonLdProjects = itemListSchema(projectsData.map(project => softwareSourceCodeSchema({
+    name: project.name,
+    description: project.description,
+    codeRepository: project.html_url,
+    author: project.owner.login,
+  })));
+
   return (
     <main className="flex w-full max-w-7xl flex-col items-center bg-background mx-auto">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLdEvents) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLdProjects) }}
+      />
       <section className={`relative flex flex-col items-center py-25 sm:py-40 px-16 max-sm:px-10 overflow-hidden after:content-[''] after:absolute after:w-[1280px] after:h-[717px] after:bg-[radial-gradient(50%_50%_at_50.03%_49.91%,_rgba(205,43,49,0.35)_0%,_rgba(255,255,255,0)_100%)] after:z-0 after:left-0 after:top-0 after:pointer-events-none max-md:after:w-full max-md:after:h-[431px] dark:after:hidden`}>
         <h1 className="text-5xl sm:text-7xl z-1 text-center font-bold mb-9 leading-[1.4] w-full sm:w-[90%]">Conecta con <span className={`relative max-md:block before:content-[''] before:block before:w-[418px] before:h-[42px] before:bg-[url('/svg/line-text.svg')] before:bg-no-repeat before:bg-cover before:absolute before:-bottom-[10px] before:left-[130px] max-md:before:w-[240px] max-md:before:h-[24px] max-md:before:top-[50px] max-md:before:left-[50px] text-primary-text`}>la comunidad tech</span> en el Perú</h1>
         <p className="text-center z-1 w-fullsm:w-[70%] text-[20px]">Descubre eventos, únete a comunidades y contribuye a proyectos de código abierto realizados en Perú.</p>

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -2,6 +2,8 @@ import Link from 'next/link';
 import type { Metadata } from 'next';
 import ProjectsClient from '../components/projects/ProjectsClient';
 import { addUTMParams } from '../lib/utm';
+import { PROJECTS } from '../data/projects';
+import { itemListSchema, softwareSourceCodeSchema } from '../lib/structured-data';
 
 export const metadata: Metadata = {
     title: 'Proyectos Open Source peruanos | Peruanos.dev',
@@ -23,8 +25,19 @@ export const metadata: Metadata = {
 };
 
 export default function Projects() {
+    const jsonLdProjects = itemListSchema(PROJECTS.map(project => softwareSourceCodeSchema({
+        name: project.repo,
+        description: `Open source project ${project.repo} by ${project.owner}`,
+        codeRepository: `https://github.com/${project.owner}/${project.repo}`,
+        author: project.owner,
+    })));
+
     return (
         <main className="flex w-full max-w-7xl flex-col items-center bg-background mx-auto">
+            <script
+                type="application/ld+json"
+                dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLdProjects) }}
+            />
             <section className="py-20 flex flex-col items-start w-full px-8 sm:px-10">
                 <h1 className="text-4xl sm:text-6xl text-left font-bold mb-4 leading-[1.4] w-full">
                     Proyectos <span className="text-primary-text">Open Source</span>


### PR DESCRIPTION
This commit adds structured data (JSON-LD) generation for the lists of events and open source projects. 

Specifically, it:
1. Adds `itemListSchema` and `softwareSourceCodeSchema` generator functions to `app/lib/structured-data.ts`.
2. Uses the schema generators on the Home (`app/page.tsx`), Events (`app/events/page.tsx`), and Projects (`app/projects/page.tsx`) pages to inject `<script type="application/ld+json">` tags containing the SEO-friendly data.

---
*PR created automatically by Jules for task [14263599746411340309](https://jules.google.com/task/14263599746411340309) started by @lperezp*