### PR TITLE
feat(events): add Meetup #3 (AI Dev Peru) event

### DIFF
--- a/app/data/events.ts
+++ b/app/data/events.ts
@@ -383,5 +383,18 @@ export const EVENTS: IEvent[] = [
         registration_url: "https://luma.com/ud0ch33f",
         tags: ["AI", "Tech", "Wellness", "Women in Tech", "WTM"],
         organizer: "WTM Lima"
+    },
+    {
+        title: "Meetup #3 (AI Dev Peru)",
+        description: "¡Bievenidos al meetup #3 de la comunidad AI Dev Peru!\nSerá un espacio donde nos pondremos al día con las últimas novedades y aprenderemos nuevas formas de trabajar de la mano de la IA.\n🗓️ Agenda\n🎤 \" IA en las trincheras: mi día a día en un early-stage startup\". Gustavo Pajuelo - CTO @ Zentum\n🎤 \"CTO en Zentum\" . Joel Ibaceta - Former CTO @ Kwema Inc\nRecomendaciones:\n- Aforo limitado, entrada por orden de llegada.\n- El local no cuenta con estacionamiento, planifica tu viaje",
+        date: "2026-03-31",
+        time: "19:00",
+        location: "NTT DATA Bloom, Av. Javier Prado Oeste 2501, Magdalena del Mar",
+        city: "Magdalena del Mar",
+        type: "Presencial",
+        image_url: "https://images.lumacdn.com/event-covers/o9/e0d47141-3f78-4001-bdf0-c5055c0b6e70.png",
+        registration_url: "https://luma.com/hd4ecwgr",
+        tags: ["AI", "Meetup"],
+        organizer: "AI Dev Peru"
     }
 ];


### PR DESCRIPTION
This PR adds a new event for "Meetup #3 (AI Dev Peru)" to the central `app/data/events.ts` database.

**Changes:**
- Appended a new `IEvent` entry to the `EVENTS` array in `app/data/events.ts`.
- Formatted and cleaned up the event's data from the given Luma link (https://luma.com/hd4ecwgr?locale=es).
- Handled timezone calculation accurately: Luma's UTC start time `2026-04-01T00:00:00.000Z` maps to `2026-03-31` at `19:00` local time (`America/Lima`).
- Confirmed frontend UI rendering through visual verification and ensured build/lint pipelines pass successfully.

---
*PR created automatically by Jules for task [16349099240025573708](https://jules.google.com/task/16349099240025573708) started by @lperezp*