### PR TITLE
feat: add AWS User Group Arequipa Meetup #8 event

### DIFF
--- a/app/data/events.ts
+++ b/app/data/events.ts
@@ -423,6 +423,19 @@ export const EVENTS: IEvent[] = [
     registration_url: 'https://gdg.community.dev/events/details/google-gdg-piura-presents-desplegando-agentes-ia-con-google-cloud-tools-1/',
     tags: ['AI', 'Build with AI', 'Google Cloud', 'Workshop'],
     organizer: 'GDG Piura'
+  },
+  {
+    title: 'Meetup #8 - AWS para Startups: aprende a aprovechar su potencial',
+    description: '☁️☁️🚀☁️☁️\nAWS para Startups: aprende a aprovechar su potencial\n\n📅 26 de marzo de 2025\n🕕 6:00 p.m. – 8:30 p.m.\n📍 Incubadora Kaman – Salaverry 301\n💻 También transmitiremos en vivo para quienes no puedan asistir presencialmente.\n\nContaremos con charlas de expertos, casos de éxito locales y mucho networking. Si estás emprendiendo o quieres optimizar los recursos de tu startup en la nube, ¡este evento es para ti!',
+    date: '2025-03-26',
+    time: '18:00',
+    location: 'Incubadora Kaman, Salaverry 301',
+    city: 'Arequipa',
+    type: 'Híbrido',
+    image_url: 'https://secure.meetupstatic.com/photos/event/d/e/c/6/highres_533277030.jpeg',
+    registration_url: 'https://www.meetup.com/aws-user-group-arequipa/events/313851125/',
+    tags: ['AWS', 'Startups', 'Cloud'],
+    organizer: 'AWS User Group Arequipa'
   }
 
 ];


### PR DESCRIPTION
Added the "Meetup #8 - AWS para Startups" event to `EVENTS` in `app/data/events.ts`. This event takes place in Arequipa and is a Hybrid event. Included high-resolution image URL.

---
*PR created automatically by Jules for task [17210482181276613331](https://jules.google.com/task/17210482181276613331) started by @lperezp*