### PR TITLE
Add LEAD UTP community

### DIFF
--- a/app/data/communities.ts
+++ b/app/data/communities.ts
@@ -370,5 +370,34 @@ export const COMMUNITIES: ICommunity[] = [
                 "instagram": ""
             }
         }
+    },
+    {
+        "name": "LEAD UTP",
+        "description": "Somos una comunidad tecnológica enfocada en formar líderes y potenciar el crecimiento profesional de estudiantes mediante eventos, aprendizaje colaborativo y networking con la industria. Promovemos el desarrollo de habilidades técnicas y blandas para impulsar el talento joven en el ecosistema tech del Perú.",
+        "logo_url": "https://raw.githubusercontent.com/LeadUTPDev/leadutp-hub/acd6d23ae92c2c4ef18e312463898460b19e781f/public/images/Logo%20oficial%20-%20Banner.png",
+        "city": "Lima",
+        "topics": [
+            "Cloud Computing",
+            "Software Development",
+            "Web Development",
+            "EdTech",
+            "Startups",
+            "AI",
+            "Innovation",
+            "Women in Tech"
+        ],
+        "contact": {
+            "email": "leadutp@gmail.com",
+            "website": "https://www.instagram.com/lead_utp/",
+            "socialMedia": {
+                "github": "",
+                "twitter": "",
+                "linkedin": "",
+                "discord": "https://discord.com/invite/EYXFUfYHbF",
+                "facebook": "",
+                "youtube": "",
+                "instagram": "https://www.instagram.com/lead_utp/"
+            }
+        }
     }
 ];

--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,10 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 'storage.tally.so',
       },
+      {
+        protocol: 'https',
+        hostname: 'raw.githubusercontent.com',
+      },
     ],
   },
 };


### PR DESCRIPTION
This PR adds the 'LEAD UTP' community to the platform. 
LEAD UTP is a student community from Universidad Tecnológica del Perú focused on leadership and professional growth in tech.
The changes include:
- Appending the community details (description, logo, topics, contact info) to `app/data/communities.ts`.
- Updating `next.config.ts` to allow loading the logo from GitHub's raw content domain.
Verified the changes visually and ensured the build and lint pass.

Fixes #106

---
*PR created automatically by Jules for task [15425069963952607661](https://jules.google.com/task/15425069963952607661) started by @lperezp*