### PR TITLE
Add FLISoL UTP - 2026 Event

### DIFF
--- a/app/data/events.ts
+++ b/app/data/events.ts
@@ -593,6 +593,18 @@ export const EVENTS: IEvent[] = [
     registration_url: "https://www.eventbrite.com.pe/e/explora-tech-lima-2026-tickets-1983718128322",
     tags: [],
     organizer: "Techspira"
+  },
+  {
+    title: "FLISoL UTP - 2026",
+    description: "Festival Latinoamericano de Instalación de Software Libre (FLISoL) en la UTP. Un día lleno de aprendizaje, tecnología y cultura open source con charlas de Linux, Ciberseguridad, IA, Hardware Abierto y más.",
+    date: "2026-04-25",
+    time: "09:00",
+    location: "UTP - Torre Arequipa",
+    city: "Lima",
+    type: "Presencial",
+    image_url: "https://images.lumacdn.com/event-covers/mc/1947c2c8-7c21-4477-aca8-c8cc1ce353c0.png",
+    registration_url: "https://luma.com/0h6u3mp6",
+    organizer: "LEAD UTP",
+    tags: ["Linux", "Open Source", "Ciberseguridad", "IA"]
   }
-
 ];

--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,10 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 'storage.tally.so',
       },
+      {
+        protocol: 'https',
+        hostname: 'images.lumacdn.com',
+      },
     ],
   },
 };


### PR DESCRIPTION
I have added the "FLISoL UTP - 2026" event to the platform. 

Key changes:
1. **Event Data:** Added the event details to `app/data/events.ts`, including the title, description, date (April 25, 2026), location (UTP - Torre Arequipa), and organizer (LEAD UTP).
2. **Image Support:** Updated `next.config.ts` to include `images.lumacdn.com` in the `remotePatterns` configuration, ensuring the event's cover image renders correctly.
3. **Verification:** Validated the changes by running `npm run lint` and `npm run build`, and confirmed the event's appearance on the `/events` page via a Playwright-automated visual check.

Fixes #107

---
*PR created automatically by Jules for task [12188036681094983926](https://jules.google.com/task/12188036681094983926) started by @lperezp*