### PR TITLE
Add cybersecurity event and Game Devs UTP community

### DIFF
--- a/app/data/communities.ts
+++ b/app/data/communities.ts
@@ -370,5 +370,30 @@ export const COMMUNITIES: ICommunity[] = [
                 "instagram": ""
             }
         }
+    },
+    {
+        "name": "Game Devs UTP",
+        "description": "Comunidad estudiantil de la Universidad Tecnológica del Perú (UTP) enfocada en impulsar el desarrollo de videojuegos y e-sports. Un espacio para aprender, compartir y crear en el mundo del gaming.",
+        "logo_url": "https://images.lumacdn.com/calendars/xk/d9cd92be-dd4f-431b-9f0f-2d44c216c1fd.jpg",
+        "city": "Lima",
+        "topics": [
+            "Game Development",
+            "Videojuegos",
+            "E-sports",
+            "Student Community"
+        ],
+        "contact": {
+            "email": "",
+            "website": "https://luma.com/calendar/cal-9tTLFpVPAWli1qo",
+            "socialMedia": {
+                "github": "",
+                "twitter": "",
+                "linkedin": "https://linkedin.com/company/gamedevsutp",
+                "discord": "",
+                "facebook": "",
+                "youtube": "",
+                "instagram": "https://instagram.com/gamedevsutp"
+            }
+        }
     }
 ];

--- a/app/data/events.ts
+++ b/app/data/events.ts
@@ -606,5 +606,18 @@ export const EVENTS: IEvent[] = [
     registration_url: "https://luma.com/0h6u3mp6",
     organizer: "LEAD UTP",
     tags: ["Linux", "Open Source", "Ciberseguridad", "IA"]
-  }
+    },
+    {
+        title: "De Jugador a Protector: Introducción a la Ciberseguridad para Gamers",
+        description: "​¿Te gustan los videojuegos y quieres entender cómo se pueden hackear… y proteger? 🎮🔐 Esta ponencia te mostrará el lado oculto de la ciberseguridad en el mundo gamer. 🔥 Lo que aprenderás: Conocerás los fundamentos de la ciberseguridad y cómo iniciar en este campo, aplicados a videojuegos. Además, verás un caso real: la vulnerabilidad Log4J en Minecraft y cómo puede usarse para ejecutar comandos en una máquina víctima. 👾 ¿Para quién es? ¡Para gamers, estudiantes y curiosos! No necesitas experiencia previa en ciberseguridad, solo interés por entender cómo proteger sistemas y descubrir el lado oculto de los videojuegos.",
+        date: "2026-04-11",
+        time: "15:00",
+        location: "Virtual",
+        city: "Lima",
+        type: "Virtual",
+        image_url: "https://images.lumacdn.com/event-covers/i6/511268fa-846c-4de5-ac7e-b9622d6d7cad.jpg",
+        registration_url: "https://luma.com/qtp6suw8",
+        tags: ["Ciberseguridad", "Gaming", "Videojuegos"],
+        organizer: "Game Devs UTP"
+    }
 ];


### PR DESCRIPTION
I have added a new event "De Jugador a Protector: Introducción a la Ciberseguridad para Gamers" and its organizing community "Game Devs UTP" to the platform. 

Key actions taken:
1. **Data Extraction**: Used a custom script to parse the Luma registration page and extract detailed event information, including the confirmed date of April 11, 2026, and community metadata.
2. **Data Integration**:
   - Registered "Game Devs UTP" in `app/data/communities.ts` with its bio, logo, and social media links (Instagram, LinkedIn).
   - Added the cybersecurity event to `app/data/events.ts` with appropriate tags and descriptions.
3. **Verification**:
   - Confirmed the data against the source's `__NEXT_DATA__` payload to ensure accuracy.
   - Ran a Playwright verification script to confirm the event renders correctly in the frontend.
   - Verified that the project lints and builds successfully without regressions.
4. **Cleanup**: Restored `package.json` and `package-lock.json` to their original state and removed all temporary diagnostic files.

Fixes #110

---
*PR created automatically by Jules for task [8994469088341951395](https://jules.google.com/task/8994469088341951395) started by @lperezp*