### PR TITLE
feat: add Notion + AI event

### DIFF
--- a/app/data/events.ts
+++ b/app/data/events.ts
@@ -162,5 +162,21 @@ export const EVENTS: IEvent[] = [
         "registration_url": "https://luma.com/z3vlgap4",
         "tags": [],
         "organizer": "Game Devs UTP"
+    },
+    {
+        "title": "Productividad al límite: Notion + AI",
+        "description": "🚀 Productividad: Lleva tu equipo al máximo con Notion y Agentes de AI 🤖✨. ¿Tu equipo busca trabajar de forma más inteligente y no más duro? Te invitamos a un evento que va a transformar la manera en que operan 💪. En este evento, podrás descubrir cómo la inteligencia artificial y los Agentes de AI en Notion están revolucionando la productividad, permitiendo que los sistemas trabajen de manera autónoma mientras tu equipo se enfoca en lo que realmente importa 🎯. Este evento es para quienes están listos para dar el salto: equipos que quieren dejar atrás los procesos manuales y construir sistemas que trabajan por ellos.",
+        "date": "2026-05-02",
+        "time": "18:00",
+        "location": "San Isidro, Provincia de Lima",
+        "city": "San Isidro",
+        "type": "Presencial",
+        "image_url": "https://images.lumacdn.com/event-covers/ti/9cfb1392-dc4d-4b3a-a861-15bf35c547d2.png",
+        "registration_url": "https://luma.com/1k8lsruf",
+        "organizer": "Notion Perú",
+        "tags": [
+            "AI",
+            "Notion"
+        ]
     }
 ];


### PR DESCRIPTION
I have added the "Productividad al límite: Notion + AI" event to the application's event data. 

Key actions taken:
- Extracted event details (title, description, date, time, location, and image) from the Luma event page.
- Appended the event to `app/data/events.ts` following the `IEvent` interface.
- Validated the change by running `npm run build` and `npm run lint`.
- Verified the frontend rendering by capturing a screenshot of the `/events` page using Playwright.
- Cleaned up all temporary scripts and stopped the development server.

Fixes #123

---
*PR created automatically by Jules for task [1492892349595554563](https://jules.google.com/task/1492892349595554563) started by @lperezp*