### PR TITLE
Add FLISoL UNI 2026 event

### DIFF
--- a/app/data/events.ts
+++ b/app/data/events.ts
@@ -178,5 +178,23 @@ export const EVENTS: IEvent[] = [
             "AI",
             "Notion"
         ]
+    },
+    {
+        "title": "FLISoL UNI 2026",
+        "description": "🚀 ¡Llega el evento de software libre más grande de Latinoamérica! Sé parte del FLISOL Perú 2026 🇵🇪 en la UNI, un espacio donde la tecnología, la innovación y la comunidad se unen para compartir conocimiento sin límites. Aprende sobre software libre, inteligencia artificial, desarrollo, cultura open source y mucho más. Disfruta de charlas, talleres y conecta con personas apasionadas por la tecnología.",
+        "date": "2026-04-25",
+        "time": "TBD",
+        "location": "Auditorio FIEE - UNI",
+        "city": "Lima",
+        "type": "Presencial",
+        "image_url": "https://media.licdn.com/dms/image/v2/D4D22AQFIMGlGhJGB8w/feedshare-shrink_800/B4DZ2XnJzTG4Ac-/0/1776365117283?e=2147483647&v=beta&t=UIL9JKDejS6jqUtfqwJAujMkenYadPmXKAqSx0QdHyg",
+        "registration_url": "https://forms.gle/3KFbnGhQeBv7X5vz8",
+        "organizer": "DSC UNI",
+        "tags": [
+            "Open Source",
+            "Software Libre",
+            "AI",
+            "Tech"
+        ]
     }
 ];

--- a/next.config.ts
+++ b/next.config.ts
@@ -23,6 +23,10 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 'lh3.googleusercontent.com',
       },
+      {
+        protocol: 'https',
+        hostname: 'media.licdn.com',
+      },
     ],
   },
 };


### PR DESCRIPTION
This change adds the FLISoL UNI 2026 event to the events list. It includes the event details extracted from LinkedIn and the registration form, and whitelists the LinkedIn media domain in the Next.js configuration to allow rendering the event image.

Fixes #119

---
*PR created automatically by Jules for task [9158200923074204413](https://jules.google.com/task/9158200923074204413) started by @lperezp*