### PR TITLE
Add "From APK to API" event to events data

### DIFF
--- a/app/data/events.ts
+++ b/app/data/events.ts
@@ -250,5 +250,24 @@ export const EVENTS: IEvent[] = [
             "Workshop"
         ],
         "organizer": "GDG Callao"
+    },
+    {
+        "title": "From APK to API: Reverse Engineering Android to Uncover & Exploit Web Backends",
+        "description": "La seguridad de las aplicaciones móviles a menudo es solo la punta del iceberg. Las verdaderas vulnerabilidades suelen ocultarse en su comunicación con los servidores. Este webinar explora cómo la ingeniería inversa de aplicaciones Android puede revelar y explotar debilidades en los web backends, llevando la auditoría de seguridad al siguiente nivel.",
+        "date": "2026-04-26",
+        "time": "16:00",
+        "location": "Google Meet",
+        "city": "Virtual",
+        "type": "Virtual",
+        "image_url": "https://images.lumacdn.com/event-covers/el/55518480-3db5-49c0-97f4-7702cd9641c8.png",
+        "registration_url": "https://luma.com/wkspf21z",
+        "organizer": "Threat Hunters UTP",
+        "tags": [
+            "Android",
+            "Reverse Engineering",
+            "Security",
+            "Web Backend",
+            "Cybersecurity"
+        ]
     }
 ];


### PR DESCRIPTION
This PR adds the "From APK to API" cybersecurity event organized by Threat Hunters UTP to the events registry.

Details added:
- **Title**: From APK to API: Reverse Engineering Android to Uncover & Exploit Web Backends
- **Organizer**: Threat Hunters UTP
- **Date**: 2026-04-26
- **Time**: 16:00
- **Location**: Google Meet (Virtual)
- **Image**: Extracted from Luma cover image.
- **Tags**: Android, Reverse Engineering, Security, Web Backend, Cybersecurity.

Verification:
- Linting and build passed.
- Frontend verification confirmed the event is visible on the `/events` page and API.
- Memory recording updated with relevant patterns.

Fixes #129

---
*PR created automatically by Jules for task [3313859213896167432](https://jules.google.com/task/3313859213896167432) started by @lperezp*