### PR TITLE
Add Tech Leaders event by LEAD UTEC

### DIFF
--- a/app/data/events.ts
+++ b/app/data/events.ts
@@ -300,5 +300,23 @@ export const EVENTS: IEvent[] = [
             "GameDev",
             "Videojuegos"
         ]
+    },
+    {
+        "title": "Tech Leaders",
+        "description": "Tech Leaders 2026 es la evolución de Data Leaders, iniciativa de LEAD UTEC que, tras dos ediciones en 2025, expande su enfoque para reunir en un solo evento a las comunidades de Software, Data, Mecatrónica y Negocios. Busca ayudar a estudiantes y jóvenes profesionales a reducir la incertidumbre sobre su futuro profesional, explorando distintas especializaciones, áreas de trabajo y experiencias reales de la industria de la mano de quienes hoy lideran esos espacios.",
+        "date": "2026-06-05",
+        "time": "16:00",
+        "location": "University of Engineering and Technology (UTEC), Jr. Medrano Silva 165, Barranco",
+        "city": "Lima",
+        "type": "Presencial",
+        "image_url": "https://images.lumacdn.com/uploads/ea/0309d89f-f927-4caa-9a68-00575bdfc1c3.jpg",
+        "registration_url": "https://lu.ma/xs1ra3xm",
+        "organizer": "Lead UTEC",
+        "tags": [
+            "Software",
+            "Data",
+            "Mecatrónica",
+            "Negocios"
+        ]
     }
 ];


### PR DESCRIPTION
This submission adds the "Tech Leaders" event, organized by LEAD UTEC, to the community event registry. 

Key changes:
- Appended the event object to the `EVENTS` array in `app/data/events.ts`.
- The event details (title, description, date, location, and registration URL) were extracted from the provided Luma link (https://lu.ma/xs1ra3xm).
- Verified that the event renders correctly on the `/events` page through visual inspection and automated scripts.
- Confirmed that the project builds and lints successfully.

Fixes #159

---
*PR created automatically by Jules for task [15868090802575470790](https://jules.google.com/task/15868090802575470790) started by @lperezp*