### PR TITLE
Add Del diseño al prototipo con Google Stitch + Antigravity event

### DIFF
--- a/app/data/events.ts
+++ b/app/data/events.ts
@@ -337,6 +337,23 @@ export const EVENTS: IEvent[] = [
         ]
     },
     {
+        "title": "Construye tu máquina de contenido con Notion & GenAI",
+        "description": "La mayoría crea contenido sin sistema: ideas dispersas, herramientas desconectadas y demasiado tiempo perdido.\n\nEn este webinar en vivo aprenderás cómo usar Notion junto a herramientas de GenAI como Runway y Google VEO para construir un flujo de contenido más rápido, organizado y escalable.\n\n¿Qué aprenderás?\n\n* Cómo convertir Notion en el centro operativo de tu contenido.\n\n* Cómo usar IA para idear, estructurar y producir contenido visual.\n\n* Cómo construir un sistema replicable para publicar de forma consistente.\n\n¿Para quién es?\n\nCreadores de contenido, founders, marketers, builders y cualquier persona que quiera crear contenido usando IA sin depender de procesos manuales.\n\nSpeakers:\n\nJhon Miranda & Mayckol Cruzado\n(Co-founders IA Labs & Notion Ambassadors",
+        "date": "2026-06-04",
+        "time": "18:00",
+        "location": "Virtual",
+        "city": "Virtual",
+        "type": "Virtual",
+        "image_url": "https://images.lumacdn.com/uploads/ow/a267cce9-d71a-411c-bae7-534445f9a851.jpg",
+        "registration_url": "https://lu.ma/bbesl0ju",
+        "organizer": "IA Labs",
+        "tags": [
+            "AI",
+            "Notion",
+            "GenAI"
+        ]
+    },
+    {
         "title": "Del diseño al prototipo con Google Stitch + Antigravity",
         "description": "Del diseño al prototipo en un solo flujo 🚀\n\nDescubre cómo acelerar la creación de productos digitales usando Google Stitch + Antigravity en un workflow moderno potenciado por IA.\n\nEn esta sesión en vivo, Daniel Ibañez (Software Engineer en Danjersoft) mostrará cómo conectar diseño, prototipado y velocidad de ejecución para construir MVPs más rápido y con menos fricción.\n\nLo que aprenderás:\n• Cómo pasar de idea → diseño → prototipo funcional en un solo flujo\n• Cómo usar Google Stitch + Antigravity para acelerar workflows de producto\n• Mejores prácticas para validar ideas y construir MVPs más rápido\n\n¿Para quién es?\nBuilders, founders, makers, diseñadores, developers y personas interesadas en IA, NoCode y creación de productos digitales.",
         "date": "2026-06-02",

--- a/app/data/events.ts
+++ b/app/data/events.ts
@@ -335,5 +335,23 @@ export const EVENTS: IEvent[] = [
             "Automation",
             "n8n"
         ]
+    },
+    {
+        "title": "Del diseño al prototipo con Google Stitch + Antigravity",
+        "description": "Del diseño al prototipo en un solo flujo 🚀\n\nDescubre cómo acelerar la creación de productos digitales usando Google Stitch + Antigravity en un workflow moderno potenciado por IA.\n\nEn esta sesión en vivo, Daniel Ibañez (Software Engineer en Danjersoft) mostrará cómo conectar diseño, prototipado y velocidad de ejecución para construir MVPs más rápido y con menos fricción.\n\nLo que aprenderás:\n• Cómo pasar de idea → diseño → prototipo funcional en un solo flujo\n• Cómo usar Google Stitch + Antigravity para acelerar workflows de producto\n• Mejores prácticas para validar ideas y construir MVPs más rápido\n\n¿Para quién es?\nBuilders, founders, makers, diseñadores, developers y personas interesadas en IA, NoCode y creación de productos digitales.",
+        "date": "2026-06-02",
+        "time": "19:00",
+        "location": "Virtual",
+        "city": "Virtual",
+        "type": "Virtual",
+        "image_url": "https://images.lumacdn.com/uploads/6u/f43ee63a-f1d8-4717-ac75-cd36edd985f0.png",
+        "registration_url": "https://lu.ma/k8wb7m52",
+        "organizer": "AI First Founders",
+        "tags": [
+            "AI",
+            "Google",
+            "Design",
+            "Prototyping"
+        ]
     }
 ];

--- a/next.config.ts
+++ b/next.config.ts
@@ -43,6 +43,10 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 'secure.meetupstatic.com',
       },
+      {
+        protocol: 'https',
+        hostname: 'storage.googleapis.com',
+      },
     ],
   },
 };


### PR DESCRIPTION
Added the new event "Del diseño al prototipo con Google Stitch + Antigravity" organized by AI First Founders. The event is scheduled for June 2, 2026, at 19:00 (converted from UTC to America/Lima time). Also whitelisted 'storage.googleapis.com' in the Next.js configuration to ensure all event images render correctly.

Fixes #163

---
*PR created automatically by Jules for task [14271244262929465888](https://jules.google.com/task/14271244262929465888) started by @lperezp*