### PR TITLE
Add Build with AI: The Final Prompt event

### DIFF
--- a/app/data/events.ts
+++ b/app/data/events.ts
@@ -388,5 +388,23 @@ export const EVENTS: IEvent[] = [
             "Cloud Computing",
             "AWS User Group Piura"
         ]
+    },
+    {
+        "title": "Build with AI: The Final Prompt",
+        "description": "Únete a nosotros para un encuentro único en GDG Callao. ¡Cerramos la temporada Build with AI junto a grandes ponentes, Google Developer Experts y la comunidad! Donde la inteligencia artificial será la protagonista. Exploraremos las últimas tendencias en IA. ¡Ven a compartir tus ideas, aprender de los Expertos y prepárate para espacios de Networking!",
+        "date": "2026-06-27",
+        "time": "09:30",
+        "location": "Universidad Tecnológica del Perú, Avenida Petit Thouars 116",
+        "city": "Lima",
+        "type": "Presencial",
+        "image_url": "https://res.cloudinary.com/startup-grind/image/upload/c_fill,dpr_2.0,f_auto,g_center,h_1080,q_100,w_1080/v1/gcs/platform-data-goog/events/blob_UdIdMuy",
+        "registration_url": "https://gdg.community.dev/events/details/google-gdg-callao-presents-build-with-ai-the-final-prompt/",
+        "organizer": "GDG Callao",
+        "tags": [
+            "AI",
+            "GDG",
+            "Google",
+            "Build with AI"
+        ]
     }
 ];


### PR DESCRIPTION
I have added the "Build with AI: The Final Prompt" event organized by GDG Callao to the `app/data/events.ts` file. 

Key actions taken:
- **Data Extraction**: Parsed the event details from the provided GDG community URL, confirming the date (June 27, 2026), location (UTP Lima), and description.
- **Consistency**: Used an existing "Build with AI" image asset from Cloudinary to maintain visual consistency with similar events in the registry.
- **Review Adjustments**: Following a code review, I formatted the address to the Peruvian standard ("Avenida Petit Thouars 116") and ensured the data file maintains a trailing newline.
- **Verification**: Confirmed that the application builds successfully (`npm run build`) and passes linting (`npm run lint`). A visual verification was also performed via a Playwright screenshot.

Fixes #169

---
*PR created automatically by Jules for task [3486360980795802950](https://jules.google.com/task/3486360980795802950) started by @lperezp*