### PR TITLE
Add CNCF Ayacucho July 2026 event

### DIFF
--- a/app/data/events.ts
+++ b/app/data/events.ts
@@ -803,5 +803,23 @@ export const EVENTS: IEvent[] = [
       "Vibe Coding",
       "Prototyping"
     ]
+  },
+  {
+    "title": "Meetup Cloud Native Ayacucho – Julio 2026",
+    "description": "Este evento está diseñado para estudiantes, desarrolladores, DevOps Engineers y entusiastas de la tecnología que quieran aprender de experiencias reales y conectar con la comunidad tecnológica de la región. 📅 Fecha: Sábado 11 de julio de 2026 🕘 Hora: 9:00 AM – 1:00 PM 📍 Lugar: Colegio de Ingenieros del Perú (CIP) – Ayacucho 🎟️ Modalidad: Presencial – Entrada gratuita (Previa inscripción)",
+    "date": "2026-07-11",
+    "time": "09:00",
+    "location": "Colegio de Ingenieros del Perú - Ayacucho, Ayacucho",
+    "city": "Ayacucho",
+    "type": "Presencial",
+    "image_url": "https://ocgroups.dev/images/ee59e4342d18a6fb1b13949c87658c0ef53b21c77be511bb732908ce394725fa.png",
+    "registration_url": "https://ocgroups.dev/cncf/group/ncz2zfb/event/wbnbz6e",
+    "organizer": "Cloud Native Ayacucho",
+    "tags": [
+      "Kubernetes",
+      "Prometheus",
+      "Base de datos",
+      "Cloud Native"
+    ]
   }
 ];


### PR DESCRIPTION
This PR adds the "Meetup Cloud Native Ayacucho – Julio 2026" event to the application's event registry (`app/data/events.ts`). 

Key details:
- **Title:** Meetup Cloud Native Ayacucho – Julio 2026
- **Date:** July 11, 2026
- **Location:** Ayacucho, Peru (Presencial)
- **Organizer:** Cloud Native Ayacucho
- **Tags:** Kubernetes, Prometheus, Cloud Native, Ayacucho

The event was verified to render correctly on the `/events` page via Playwright, and the build/lint processes passed successfully.

---
*PR created automatically by Jules for task [1459661735547359534](https://jules.google.com/task/1459661735547359534) started by @lperezp*