### PR TITLE
Add DevOpsDays Lima 2026 Event

### DIFF
--- a/app/data/events.ts
+++ b/app/data/events.ts
@@ -821,5 +821,23 @@ export const EVENTS: IEvent[] = [
       "Base de datos",
       "Cloud Native"
     ]
+  },
+  {
+    "title": "DevOpsDays Lima 2026",
+    "description": "Este 27 y 28 de agosto del 2026, por 2do año consecutivo, el Centro de Convenciones Lima se convierte en el punto de encuentro de quienes están transformando la forma en que se construye, despliega y opera software en la región. Acceso a charlas, talleres y networking con toda la comunidad DevOps. Ideal para quienes vienen a aprender, conectar y descubrir lo último en plataforma, IA, seguridad y cultura de ingeniería.",
+    "date": "2026-08-27",
+    "time": "09:00",
+    "location": "Centro de Convenciones Lima, Av. de la Arqueología 206, San Borja",
+    "city": "Lima",
+    "type": "Presencial",
+    "image_url": "https://tickets.devopsdays.pe/web/image/1012-b4d5f027/Evento%20%27DevOpsDays%20Lima%202026%27%20cover%20image.webp",
+    "registration_url": "http://entradas.devopsdays.pe/",
+    "tags": [
+      "DevOps",
+      "IA",
+      "Seguridad",
+      "Cultura de ingeniería"
+    ],
+    "organizer": "DevOpsDays Lima"
   }
 ];

--- a/next.config.ts
+++ b/next.config.ts
@@ -79,6 +79,10 @@ const nextConfig: NextConfig = {
       {
         protocol: 'https',
         hostname: 'avatars.githubusercontent.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'tickets.devopsdays.pe',
       }
     ],
   },


### PR DESCRIPTION
I have added the "DevOpsDays Lima 2026" event to the application. 

Key changes:
- Added the event entry to `app/data/events.ts` with all relevant details extracted from the registration portal.
- Updated `next.config.ts` to allow images from `tickets.devopsdays.pe`, ensuring the event's cover image loads correctly.
- Verified the changes by running a local development server and using a Playwright script to confirm that the event title and registration link are correctly displayed on the `/events` page.
- Ensured the codebase remains clean by running linting and build checks.

Fixes #197

---
*PR created automatically by Jules for task [13838520059677524212](https://jules.google.com/task/13838520059677524212) started by @lperezp*