### PR TITLE
Add Dragon Sphere Origins: Cyber Security Conference event

### DIFF
--- a/app/data/events.ts
+++ b/app/data/events.ts
@@ -874,5 +874,23 @@ export const EVENTS: IEvent[] = [
       "Web"
     ],
     "organizer": "GDG Callao"
+  },
+  {
+    "title": "Dragon Sphere Origins: Cyber Security Conference 🐉",
+    "description": "Dragon Sphere Origins: Cyber Conference es un CTF para principiantes. Resuelve retos reales de ciberseguridad, captura flags y escala el scoreboard. El evento presencial es el sábado 25 de julio en la PUCP, con charlas magistrales, networking y premiación a los ganadores del CTF.",
+    "date": "2026-07-25",
+    "time": "09:30",
+    "location": "Auditorio de la Facultad de Ciencias e Ingeniería – PUCP",
+    "city": "San Miguel",
+    "type": "Presencial",
+    "image_url": "https://images.lumacdn.com/uploads/0k/04c17b61-e899-4926-af93-26d8537202a9.jpg",
+    "registration_url": "https://www.dragon-sphere.com/",
+    "tags": [
+      "Ciberseguridad",
+      "CTF",
+      "Hacking Ético",
+      "PUCP"
+    ],
+    "organizer": "IEEE COMSOC PUCP & IEEE CS PUCP"
   }
 ];


### PR DESCRIPTION
Registered the "Dragon Sphere Origins: Cyber Security Conference 🐉" event in `app/data/events.ts`. Verified the event details (date, time, location, organizer, and registration URL) from the official website and Luma page. Performed syntax validation, linting, and a full production build. Verified the frontend display using a Playwright script.

Fixes #201

---
*PR created automatically by Jules for task [1326583473695989535](https://jules.google.com/task/1326583473695989535) started by @lperezp*