### PR TITLE
feat: add global and individual event calendar subscriptions

### DIFF
--- a/app/api/events/calendar/route.ts
+++ b/app/api/events/calendar/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import ical from 'ical-generator';
+import { EVENTS } from '@/app/data/events';
+
+export const revalidate = 3600;
+
+export async function GET() {
+  const calendar = ical({
+    name: 'Eventos peruanos.dev',
+    description: 'Calendario de eventos de la comunidad peruanos.dev',
+    timezone: 'America/Lima'
+  });
+
+  EVENTS.forEach((event) => {
+    // Basic date parsing. Note: time needs to be combined with date
+    const startDate = new Date(`${event.date}T${event.time}:00-05:00`);
+
+    // Default duration of 2 hours if not specified
+    const endDate = new Date(startDate.getTime() + 2 * 60 * 60 * 1000);
+
+    calendar.createEvent({
+      start: startDate,
+      end: endDate,
+      summary: event.title,
+      description: `${event.description}\n\nEnlace: ${event.registration_url}`,
+      location: `${event.location}, ${event.city}`,
+      url: event.registration_url,
+    });
+  });
+
+  return new NextResponse(calendar.toString(), {
+    headers: {
+      'Content-Type': 'text/calendar; charset=utf-8',
+      'Content-Disposition': 'attachment; filename="peruanos-dev-events.ics"',
+    },
+  });
+}

--- a/app/components/events/AddToCalendarDropdown.tsx
+++ b/app/components/events/AddToCalendarDropdown.tsx
@@ -34,7 +34,7 @@ export default function AddToCalendarDropdown({ event }: Props) {
             <button
                 type="button"
                 onClick={toggleDropdown}
-                className="flex items-center mt-4 gap-2 font-semibold text-secondary hover:text-secondary-foreground transition-colors"
+                className="flex items-center mt-4 gap-2 font-semibold text-foreground hover:text-accent transition-colors"
             >
                 Agregar al calendario
                 <CalendarPlus size={16} />
@@ -47,7 +47,7 @@ export default function AddToCalendarDropdown({ event }: Props) {
                             href={googleCalendarUrl}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="flex items-center px-4 py-2 text-sm text-foreground hover:bg-accent hover:text-accent-foreground"
+                            className="flex items-center px-4 py-2 text-sm text-foreground hover:bg-hover hover:text-foreground"
                             role="menuitem"
                             eventName="add_to_google_calendar"
                             eventParams={{ event_title: event.title }}
@@ -59,7 +59,7 @@ export default function AddToCalendarDropdown({ event }: Props) {
                         <TrackedLink
                             href={icsDataUrl}
                             download={`${event.title.replace(/[^a-z0-9]/gi, '_').toLowerCase()}.ics`}
-                            className="flex items-center px-4 py-2 text-sm text-foreground hover:bg-accent hover:text-accent-foreground"
+                            className="flex items-center px-4 py-2 text-sm text-foreground hover:bg-hover hover:text-foreground"
                             role="menuitem"
                             eventName="download_ics_calendar"
                             eventParams={{ event_title: event.title }}

--- a/app/components/events/AddToCalendarDropdown.tsx
+++ b/app/components/events/AddToCalendarDropdown.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import { CalendarPlus, Download, ExternalLink } from 'lucide-react';
+import { IEvent } from '../../models/event.model';
+import { generateGoogleCalendarUrl, generateIcsDataUrl } from '../../utils/calendar';
+import TrackedLink from '../ui/TrackedLink';
+
+interface Props {
+    event: IEvent;
+}
+
+export default function AddToCalendarDropdown({ event }: Props) {
+    const [isOpen, setIsOpen] = useState(false);
+    const dropdownRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        function handleClickOutside(event: MouseEvent) {
+            if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+                setIsOpen(false);
+            }
+        }
+        document.addEventListener('mousedown', handleClickOutside);
+        return () => document.removeEventListener('mousedown', handleClickOutside);
+    }, []);
+
+    const toggleDropdown = () => setIsOpen(!isOpen);
+
+    const googleCalendarUrl = generateGoogleCalendarUrl(event);
+    const icsDataUrl = generateIcsDataUrl(event);
+
+    return (
+        <div className="relative inline-block text-left" ref={dropdownRef}>
+            <button
+                type="button"
+                onClick={toggleDropdown}
+                className="flex items-center mt-4 gap-2 font-semibold text-secondary hover:text-secondary-foreground transition-colors"
+            >
+                Agregar al calendario
+                <CalendarPlus size={16} />
+            </button>
+
+            {isOpen && (
+                <div className="absolute z-10 mt-2 w-48 rounded-md shadow-lg bg-background border border-accent ring-1 ring-black ring-opacity-5 focus:outline-none">
+                    <div className="py-1" role="menu" aria-orientation="vertical">
+                        <TrackedLink
+                            href={googleCalendarUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="flex items-center px-4 py-2 text-sm text-foreground hover:bg-accent hover:text-accent-foreground"
+                            role="menuitem"
+                            eventName="add_to_google_calendar"
+                            eventParams={{ event_title: event.title }}
+                            onClick={() => setIsOpen(false)}
+                        >
+                            <ExternalLink size={14} className="mr-2" />
+                            Google Calendar
+                        </TrackedLink>
+                        <TrackedLink
+                            href={icsDataUrl}
+                            download={`${event.title.replace(/[^a-z0-9]/gi, '_').toLowerCase()}.ics`}
+                            className="flex items-center px-4 py-2 text-sm text-foreground hover:bg-accent hover:text-accent-foreground"
+                            role="menuitem"
+                            eventName="download_ics_calendar"
+                            eventParams={{ event_title: event.title }}
+                            onClick={() => setIsOpen(false)}
+                        >
+                            <Download size={14} className="mr-2" />
+                            Descargar .ics
+                        </TrackedLink>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/app/components/events/EventCard.tsx
+++ b/app/components/events/EventCard.tsx
@@ -19,8 +19,8 @@ export default function CardEvent({ event }: Props) {
     const year = dateObj.getUTCFullYear();
 
     return (
-        <div className="bg-background border border-accent rounded-lg overflow-hidden flex flex-col sm:flex-row sm:h-[300px]">
-            <div className="relative w-full sm:w-[300px] h-64 sm:h-full flex-shrink-0">
+        <div className="bg-background border border-accent rounded-lg flex flex-col sm:flex-row sm:h-[300px]">
+            <div className="relative w-full sm:w-[300px] h-64 sm:h-full flex-shrink-0 overflow-hidden rounded-t-lg sm:rounded-none sm:rounded-l-lg">
                 {event.image_url ? (
                     <Image
                         src={event.image_url}

--- a/app/components/events/EventCard.tsx
+++ b/app/components/events/EventCard.tsx
@@ -3,6 +3,8 @@ import { ExternalLink, MapPin } from 'lucide-react';
 import { IEvent } from '../../models/event.model';
 import Badge from '../ui/Badge';
 import TrackedLink from '../ui/TrackedLink';
+import AddToCalendarDropdown from './AddToCalendarDropdown';
+
 import { addUTMParams } from '../../lib/utm';
 
 interface Props {
@@ -50,17 +52,22 @@ export default function CardEvent({ event }: Props) {
                     <MapPin size={16} />
                     <span>{event.location}</span>
                 </div>
-                <TrackedLink
-                    href={addUTMParams(event.registration_url)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center mt-4 gap-2 font-medium text-primary font-semibold"
-                    eventName="click_register_event"
-                    eventParams={{ event_title: event.title, event_type: event.type }}
-                >
-                    Registrarse
-                    <ExternalLink size={16} />
-                </TrackedLink>
+
+                <div className="flex items-center gap-4">
+                    <TrackedLink
+                        href={addUTMParams(event.registration_url)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex items-center mt-4 gap-2 font-medium text-primary font-semibold"
+                        eventName="click_register_event"
+                        eventParams={{ event_title: event.title, event_type: event.type }}
+                    >
+                        Registrarse
+                        <ExternalLink size={16} />
+                    </TrackedLink>
+                    <AddToCalendarDropdown event={event} />
+                </div>
+
             </div>
         </div>
     );

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -71,7 +71,7 @@ export default function Events() {
                     </Link>
                     <TrackedLink
                         href="/api/events/calendar"
-                        className="flex justify-center items-center gap-2 px-6 py-3 text-center bg-secondary text-white rounded-full hover:bg-secondary-hover transition"
+                        className="flex justify-center items-center gap-2 px-6 py-3 text-center bg-secondary text-secondary-foreground rounded-full hover:bg-secondary-hover transition"
                         eventName="download_calendar_all_events"
                     >
                         <Download size={20} />

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,6 +1,10 @@
 import Link from 'next/link';
 import type { Metadata } from 'next';
 import EventsClient from '../components/events/EventsClient';
+
+import { Download } from 'lucide-react';
+import TrackedLink from '../components/ui/TrackedLink';
+
 import { addUTMParams } from '../lib/utm';
 import { EVENTS } from '../data/events';
 import { eventSchema, itemListSchema } from '../lib/structured-data';
@@ -55,14 +59,26 @@ export default function Events() {
                 <p className="text-left mb-4 w-full sm:text-[20px]">
                     Conecta con la comunidad tech peruana en eventos, meetups y conferencias. ¿Organizas un evento? ¡Agrégalo a la lista!
                 </p>
-                <Link
-                    className="px-6 py-3 text-center bg-primary text-white rounded-full hover:bg-primary-hover transition"
-                    href={addUTMParams('https://github.com/lperezp/peruanos.dev/issues/new?template=event.yml')}
-                    target='_blank'
-                    rel="noopener noreferrer"
-                >
-                    Publicar un evento
-                </Link>
+
+                <div className="flex flex-col sm:flex-row gap-4 mt-6">
+                    <Link
+                        className="px-6 py-3 text-center bg-primary text-white rounded-full hover:bg-primary-hover transition"
+                        href={addUTMParams('https://github.com/lperezp/peruanos.dev/issues/new?template=event.yml')}
+                        target='_blank'
+                        rel="noopener noreferrer"
+                    >
+                        Publicar un evento
+                    </Link>
+                    <TrackedLink
+                        href="/api/events/calendar"
+                        className="flex justify-center items-center gap-2 px-6 py-3 text-center bg-secondary text-white rounded-full hover:bg-secondary-hover transition"
+                        eventName="download_calendar_all_events"
+                    >
+                        <Download size={20} />
+                        Suscribirse al calendario
+                    </TrackedLink>
+                </div>
+
 
                 <EventsClient />
             </section>

--- a/app/globals.css
+++ b/app/globals.css
@@ -13,6 +13,9 @@
   --color-accent: var(--color-accent);
   --color-hover: var(--color-hover);
   --color-border: var(--color-border);
+  --color-secondary: var(--color-secondary);
+  --color-secondary-hover: var(--color-secondary-hover);
+  --color-secondary-foreground: var(--color-secondary-foreground);
 }
 
 :root {
@@ -38,6 +41,10 @@
   --color-accent: #6B6B6B;
   --color-hover: #E8E8E8;
   --color-border: rgba(0, 0, 0, 0.1);
+
+  --color-secondary: #0F0F11;
+  --color-secondary-hover: #2A2A2D;
+  --color-secondary-foreground: #FFFFFF;
 }
 
 [data-theme='dark'] {
@@ -54,6 +61,10 @@
   --color-accent: #979797;
   --color-hover: #2A2A2D;
   --color-border: rgba(255, 255, 255, 0.1);
+
+  --color-secondary: #FFFFFF;
+  --color-secondary-hover: #E8E8E8;
+  --color-secondary-foreground: #0F0F11;
 }
 
 /* Base Styles */

--- a/app/utils/calendar.ts
+++ b/app/utils/calendar.ts
@@ -1,0 +1,43 @@
+import { IEvent } from '../models/event.model';
+
+export function generateGoogleCalendarUrl(event: IEvent) {
+  const startDate = new Date(`${event.date}T${event.time}:00-05:00`);
+  const endDate = new Date(startDate.getTime() + 2 * 60 * 60 * 1000);
+
+  const startStr = startDate.toISOString().replace(/-|:|\.\d\d\d/g, '');
+  const endStr = endDate.toISOString().replace(/-|:|\.\d\d\d/g, '');
+
+  const url = new URL('https://calendar.google.com/calendar/render');
+  url.searchParams.append('action', 'TEMPLATE');
+  url.searchParams.append('text', event.title);
+  url.searchParams.append('dates', `${startStr}/${endStr}`);
+  url.searchParams.append('details', `${event.description}\n\nEnlace: ${event.registration_url}`);
+  url.searchParams.append('location', `${event.location}, ${event.city}`);
+
+  return url.toString();
+}
+
+export function generateIcsDataUrl(event: IEvent) {
+  const startDate = new Date(`${event.date}T${event.time}:00-05:00`);
+  const endDate = new Date(startDate.getTime() + 2 * 60 * 60 * 1000);
+
+  const startStr = startDate.toISOString().replace(/-|:|\.\d\d\d/g, '');
+  const endStr = endDate.toISOString().replace(/-|:|\.\d\d\d/g, '');
+
+  const icsContent = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//peruanos.dev//ES',
+    'BEGIN:VEVENT',
+    `DTSTART:${startStr}`,
+    `DTEND:${endStr}`,
+    `SUMMARY:${event.title.replace(/,/g, '\\,')}`,
+    `DESCRIPTION:${event.description.replace(/\n/g, '\\n').replace(/,/g, '\\,')}\\n\\nEnlace: ${event.registration_url}`,
+    `LOCATION:${event.location.replace(/,/g, '\\,')}, ${event.city}`,
+    `URL:${event.registration_url}`,
+    'END:VEVENT',
+    'END:VCALENDAR'
+  ].join('\r\n');
+
+  return `data:text/calendar;charset=utf8,${encodeURIComponent(icsContent)}`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@vercel/analytics": "^1.6.1",
+        "ical-generator": "^11.1.0",
         "lucide-react": "^0.562.0",
         "next": "16.1.1",
         "react": "19.2.3",
@@ -4254,6 +4255,54 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/ical-generator": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/ical-generator/-/ical-generator-11.1.0.tgz",
+      "integrity": "sha512-/CSyXcelySK5qYAUxXnwzhAi1UPVnapnVMXqkRQ+L0RXHCFtzqLm92o5PD0ZRhaWBCtkS0hP8YIxMrSRZ+8Zug==",
+      "license": "MIT",
+      "engines": {
+        "node": "22 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@touch4it/ical-timezones": ">=1.6.0",
+        "@types/luxon": ">= 1.26.0",
+        "@types/mocha": ">= 8.2.1",
+        "dayjs": ">= 1.10.0",
+        "luxon": ">= 1.26.0",
+        "moment": ">= 2.29.0",
+        "moment-timezone": ">= 0.5.33",
+        "rrule": ">= 2.6.8"
+      },
+      "peerDependenciesMeta": {
+        "@touch4it/ical-timezones": {
+          "optional": true
+        },
+        "@types/luxon": {
+          "optional": true
+        },
+        "@types/mocha": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        },
+        "moment-timezone": {
+          "optional": true
+        },
+        "rrule": {
+          "optional": true
+        }
       }
     },
     "node_modules/ignore": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@vercel/analytics": "^1.6.1",
+    "ical-generator": "^11.1.0",
     "lucide-react": "^0.562.0",
     "next": "16.1.1",
     "react": "19.2.3",


### PR DESCRIPTION
Added support for users to subscribe to a global events calendar and save individual events to their calendars.

Changes:
- Installed `ical-generator` to dynamically build the calendar feed for all events.
- Created `app/api/events/calendar/route.ts` to expose the global `.ics` feed.
- Created `app/utils/calendar.ts` to manage calendar-related utilities, including generating Google Calendar event URLs and data URLs for `.ics` file downloads of single events.
- Created `AddToCalendarDropdown.tsx` component inside `app/components/events/` and integrated it into `EventCard.tsx`.
- Updated `app/events/page.tsx` to include a prominent "Suscribirse al calendario" button.
- Updated `app/globals.css` with secondary color variables for proper dark/light mode button styling.

---
*PR created automatically by Jules for task [6588493449333860224](https://jules.google.com/task/6588493449333860224) started by @lperezp*